### PR TITLE
sets the Platform target of the three sample programs from AnyCPU to …

### DIFF
--- a/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 3.5.csproj
+++ b/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 3.5.csproj
@@ -16,7 +16,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 4.0.csproj
+++ b/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 4.0.csproj
@@ -16,7 +16,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 4.5.csproj
+++ b/xZune.Vlc.Wpf.Sample/xZune.Vlc.Wpf.Sample - .Net 4.5.csproj
@@ -15,7 +15,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>


### PR DESCRIPTION
…x86. In x64 builds the libVlc cant be loaded. (Default for AnyCPU was changed in vs15 from x86 to x64)