### PR TITLE
Fix crash bug in GetVideoPositionX with null _context.

### DIFF
--- a/xZune.Vlc.Wpf/VlcPlayer.cs
+++ b/xZune.Vlc.Wpf/VlcPlayer.cs
@@ -693,6 +693,10 @@ namespace xZune.Vlc.Wpf
 
     int GetVideoPositionX(double x)
     {
+      if (_context == null)
+      {
+        return (int)x;
+      }
       double width = _context.Width * ScaleTransform.ScaleX,
           height = _context.Height * ScaleTransform.ScaleY;
       var px = 0;


### PR DESCRIPTION
Self explanatory. This function can sometimes be called when _context is null (although it is difficult to replicate).