### PR TITLE
- added note to Sample's AssemblyInfo regarding the need to use --rtcp-tcp to connnect to RTSP stream through a VPN (e.g. for IP Camera behind firewall). Else one sees no video

### DIFF
--- a/xZune.Vlc.Wpf.Sample/Properties/AssemblyInfo.cs
+++ b/xZune.Vlc.Wpf.Sample/Properties/AssemblyInfo.cs
@@ -18,14 +18,14 @@ using xZune.Vlc;
 [assembly: VlcSettings(@"..\..\libvlc", new[]
             {
                 "-I", "dummy", "--ignore-config", "--no-video-title","--file-logging","--logfile=log.txt","--verbose=2","--no-sub-autodetect-file"
-            })]
+            })] //note: you may need to add the option --rtsp-tcp to pass RTSP through a VPN (e.g if you want to access some IP Camera behind a firewall by tunneling to its local network via VPN)
 
 // 将 ComVisible 设置为 false 使此程序集中的类型
 // 对 COM 组件不可见。  如果需要从 COM 访问此程序集中的类型，
 // 则将该类型上的 ComVisible 特性设置为 true。
 [assembly: ComVisible(false)]
 
-//若要开始生成可本地化的应用程序，请在 
+//若要开始生成可本地化的应用程序，请在
 //<PropertyGroup> 中的 .csproj 文件中
 //设置 <UICulture>CultureYouAreCodingWith</UICulture>。  例如，如果您在源文件中
 //使用的是美国英语，请将 <UICulture> 设置为 en-US。  然后取消
@@ -37,7 +37,7 @@ using xZune.Vlc;
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //主题特定资源词典所处位置
-    //(在页面或应用程序资源词典中 
+    //(在页面或应用程序资源词典中
     // 未找到某个资源的情况下使用)
     ResourceDictionaryLocation.SourceAssembly //常规资源词典所处位置
     //(在页面、应用程序或任何主题特定资源词典中
@@ -45,15 +45,15 @@ using xZune.Vlc;
 )]
 
 
-// 程序集的版本信息由下面四个值组成: 
+// 程序集的版本信息由下面四个值组成:
 //
 //      主版本
-//      次版本 
+//      次版本
 //      生成号
 //      修订号
 //
 // 可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值，
-// 方法是按如下所示使用“*”: 
+// 方法是按如下所示使用“*”:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("15.10.25.0")]
 [assembly: AssemblyFileVersion("15.10.25.0")]


### PR DESCRIPTION
…p-tcp VLC parameter to pass RTSP through a VPN (e.g if you want to access some IP Camera behind a firewall by tunneling to its local network via VPN)