### PR TITLE
Fix lock state where the application could freeze if VLC…

### DIFF
--- a/xZune.Vlc.Wpf/VlcPlayer.cs
+++ b/xZune.Vlc.Wpf/VlcPlayer.cs
@@ -1832,8 +1832,7 @@ namespace xZune.Vlc.Wpf
         {
             var oldState = State;
             State = VlcMediaPlayer.State;
-
-            if (State == MediaState.Paused)
+            if (State == MediaState.Paused || State == MediaState.Ended)
             {
                 _stopWaitHandle.Set();
                 return;


### PR DESCRIPTION
… didn't change its state to Paused (sometimes it sets it to Ended instead when a video ends). This fixes a bug that I often ran into in StopAsync() where _stopWaitHandle would never be set. 