### PR TITLE
Fix null references & enable multiple VLC controls

### DIFF
--- a/xZune.Vlc.Wpf/Extension.cs
+++ b/xZune.Vlc.Wpf/Extension.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace xZune.Vlc.Wpf
 {
@@ -26,24 +27,19 @@ namespace xZune.Vlc.Wpf
                 return safeValue;
             }
         }
-
+        
         /// <summary>
-        /// Return this value, if one of objs is null return default(T).
+        /// Return the value from the selector, unless the object is null. Then return the default value.
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TRet"></typeparam>
         /// <param name="value"></param>
-        /// <param name="objs"></param>
+        /// <param name="selector"></param>
+        /// <param name="defaultValue"></param>
         /// <returns></returns>
-        public static T DefaultValueWhenNull<T>(this T value, params object[] objs)
+        public static TRet DefaultValueWhenNull<T,TRet>(this T value, Func<T,TRet> selector, TRet defaultValue = default(TRet))
         {
-            if (objs.All(o => o != null))
-            {
-                return value;
-            }
-            else
-            {
-                return default(T);
-            }
+            return value == null ? defaultValue : selector(value);
         }
     }
 }

--- a/xZune.Vlc.Wpf/VlcPlayer.Properties.cs
+++ b/xZune.Vlc.Wpf/VlcPlayer.Properties.cs
@@ -18,7 +18,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public float Position
         {
-            get { return VlcMediaPlayer.Position.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Position); }
             set
             {
                 if (Position == value || VlcMediaPlayer == null || !IsSeekable) return;
@@ -35,7 +35,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public TimeSpan Time
         {
-            get { return VlcMediaPlayer.Time.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Time); }
             set
             {
                 if (Time == value || VlcMediaPlayer == null || !IsSeekable) return;
@@ -52,7 +52,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public float FPS
         {
-            get { return VlcMediaPlayer.Fps.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Fps); }
         }
 
         #endregion FPS
@@ -64,7 +64,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public bool IsMute
         {
-            get { return VlcMediaPlayer.IsMute.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.IsMute); }
             set
             {
                 if (IsMute == value || VlcMediaPlayer == null) return;
@@ -90,7 +90,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int Volume
         {
-            get { return VlcMediaPlayer.Volume.SafeValueWhenNull(100, VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Volume, 100); }
             set
             {
                 if (Volume == value || VlcMediaPlayer == null) return;
@@ -116,7 +116,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public AudioOutputChannel AudioOutputChannel
         {
-            get { return VlcMediaPlayer.AudioOutputChannel.SafeValueWhenNull(AudioOutputChannel.Error, VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.AudioOutputChannel, AudioOutputChannel.Error); }
             set
             {
                 if (AudioOutputChannel == value || VlcMediaPlayer == null) return;
@@ -133,7 +133,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int AudioTrackCount
         {
-            get { return VlcMediaPlayer.AudioTrackCount.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.AudioTrackCount); }
         }
 
         #endregion AudioTrackCount
@@ -145,7 +145,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int AudioTrack
         {
-            get { return VlcMediaPlayer.AudioTrack.SafeValueWhenNull(-1, VlcMediaPlayer); } //note: assuming a 0-based index
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.AudioTrack, - 1); } //note: assuming a 0-based index
             set
             {
                 if (AudioTrack == value || VlcMediaPlayer == null) return;
@@ -162,7 +162,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public TrackDescription AudioTrackDescription
         {
-            get { return (VlcMediaPlayer != null) ? VlcMediaPlayer.AudioTrackDescription : null; }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.AudioTrackDescription); }
         }
 
         #endregion AudioTrackDescription
@@ -174,7 +174,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public float Rate
         {
-            get { return (VlcMediaPlayer != null) ? VlcMediaPlayer.Rate : 0; }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Rate); }
             set
             {
                 if (Rate == value || VlcMediaPlayer == null) return;
@@ -191,7 +191,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int Title
         {
-            get { return VlcMediaPlayer.Title.SafeValueWhenNull(-1, VlcMediaPlayer); } //note: assuming a 0-based index
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Title, -1); } //note: assuming a 0-based index
             set
             {
                 if (Title == value || VlcMediaPlayer == null) return;
@@ -208,7 +208,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int TitleCount
         {
-            get { return VlcMediaPlayer.TitleCount.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.TitleCount); }
         }
 
         #endregion TitleCount
@@ -237,7 +237,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public int ChapterCount
         {
-            get { return VlcMediaPlayer.ChapterCount.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.ChapterCount); }
         }
 
         #endregion ChapterCount
@@ -249,7 +249,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public bool IsSeekable
         {
-            get { return VlcMediaPlayer.IsSeekable.SafeValueWhenNull(true, VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.IsSeekable, true); }
         }
 
         #endregion IsSeekable
@@ -261,7 +261,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public MediaState State
         {
-            get { return VlcMediaPlayer.State.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.State); }
         }
 
         #endregion State
@@ -273,7 +273,7 @@ namespace xZune.Vlc.Wpf
         /// </summary>
         public TimeSpan Length
         {
-            get { return VlcMediaPlayer.Length.DefaultValueWhenNull(VlcMediaPlayer); }
+            get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Length); }
         }
 
         #endregion Length

--- a/xZune.Vlc.Wpf/VlcPlayer.cs
+++ b/xZune.Vlc.Wpf/VlcPlayer.cs
@@ -66,42 +66,39 @@ namespace xZune.Vlc.Wpf
             ScaleTransform = new ScaleTransform(1, 1);
             if (!DesignerProperties.GetIsInDesignMode(this))
             {
-                if (!ApiManager.IsInitialized)
+                String libVlcPath = null;
+                String[] libVlcOption = null;
+
+                var vlcSettings =
+                    System.Reflection.Assembly.GetEntryAssembly()
+                        .GetCustomAttributes(typeof (VlcSettingsAttribute), false);
+
+                if (vlcSettings.Length > 0)
                 {
-                    String libVlcPath = null;
-                    String[] libVlcOption = null;
+                    var vlcSettingsAttribute = vlcSettings[0] as VlcSettingsAttribute;
 
-                    var vlcSettings =
-                        System.Reflection.Assembly.GetEntryAssembly()
-                            .GetCustomAttributes(typeof(VlcSettingsAttribute), false);
-
-                    if (vlcSettings.Length > 0)
+                    if (vlcSettingsAttribute != null && vlcSettingsAttribute.LibVlcPath != null)
                     {
-                        var vlcSettingsAttribute = vlcSettings[0] as VlcSettingsAttribute;
-
-                        if (vlcSettingsAttribute != null && vlcSettingsAttribute.LibVlcPath != null)
-                        {
-                            libVlcPath = Path.IsPathRooted(vlcSettingsAttribute.LibVlcPath)
-                                ? vlcSettingsAttribute.LibVlcPath
-                                : CombinePath(
-                                    Path.GetDirectoryName(
-                                        System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName),
-                                    vlcSettingsAttribute.LibVlcPath);
-                        }
-
-                        if (vlcSettingsAttribute != null && vlcSettingsAttribute.VlcOption != null)
-                            libVlcOption = vlcSettingsAttribute.VlcOption;
+                        libVlcPath = Path.IsPathRooted(vlcSettingsAttribute.LibVlcPath)
+                            ? vlcSettingsAttribute.LibVlcPath
+                            : CombinePath(
+                                Path.GetDirectoryName(
+                                    System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName),
+                                vlcSettingsAttribute.LibVlcPath);
                     }
 
-                    if (LibVlcPath != null)
-                        libVlcPath = Path.IsPathRooted(LibVlcPath) ? LibVlcPath : CombinePath(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), LibVlcPath);
-
-                    if (VlcOption != null)
-                        libVlcOption = VlcOption;
-
-                    if (libVlcPath != null)
-                        Initialize(libVlcPath, libVlcOption);
+                    if (vlcSettingsAttribute != null && vlcSettingsAttribute.VlcOption != null)
+                        libVlcOption = vlcSettingsAttribute.VlcOption;
                 }
+
+                if (LibVlcPath != null)
+                    libVlcPath = Path.IsPathRooted(LibVlcPath) ? LibVlcPath : CombinePath(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), LibVlcPath);
+
+                if (VlcOption != null)
+                    libVlcOption = VlcOption;
+
+                if (libVlcPath != null)
+                    Initialize(libVlcPath, libVlcOption);
             }
             base.OnInitialized(e);
         }
@@ -129,9 +126,10 @@ namespace xZune.Vlc.Wpf
         /// <param name="libVlcOption"></param>
         public void Initialize(String libVlcPath, params String[] libVlcOption)
         {
-            if (ApiManager.IsInitialized) return;
-
-            ApiManager.Initialize(libVlcPath, libVlcOption);
+            if (!ApiManager.IsInitialized)
+            {
+                ApiManager.Initialize(libVlcPath, libVlcOption);
+            }
 
             VlcMediaPlayer = ApiManager.Vlc.CreateMediaPlayer();
             if (VlcMediaPlayer != null)


### PR DESCRIPTION
There are two fixes in this PR.

The first is around `DefaultValueWhenNull` extension method. I believe the intention was that whenever `VlcMediaPlayer` is null then `default(T)` is returned. However, what was happening was the extension method would never be called because `VlcMediaPlayer.Time` would cause a null ref exception. I've fixed this.

```c#
public TimeSpan Length
{
  get { return VlcMediaPlayer.DefaultValueWhenNull(x => x.Length); }
}
```

The other is that it used to be possible to have multiple instances of the VLC control in an app. But because of the checks to `ApiManager.IsInitialized` the `VlcMediaPlayer` would never be created. I've massaged this behavior a bit. I'm sure there are some negative side effects to this that we'll need to work through, but it is essential for my work.